### PR TITLE
Add open with TTL

### DIFF
--- a/tests/test_rocksdb.py
+++ b/tests/test_rocksdb.py
@@ -132,9 +132,16 @@ def test_secondary_catch_up_primary(tmp_path):
     secondary_path = tmp_path / 'secondary'
     db_secondary = rocksdb3.open_as_secondary(str(primary_path),
                                               str(secondary_path))
-    assert db_secondary.get(b'author') == None
+    assert db_secondary.get(b'author') is None
     db_primary.put(b'author', b'xyb')
 
     db_secondary.try_catch_up_with_primary()
 
     assert db_secondary.get(b'author') == b'xyb'
+
+
+def test_open_with_ttl(tmp_path):
+    db_path = tmp_path / 'ttl'
+    db = rocksdb3.open_with_ttl(str(db_path), int(60))
+
+    assert db.get(b'open_with_ttl') is None


### PR DESCRIPTION
I have added [struct.DB.html#method.open_with_ttl](https://docs.rs/rocksdb/0.15.0/rocksdb/struct.DB.html#method.open_with_ttl) and I have added basic compaction method to test full compaction so the record will removed when compaction hit.

Please use the patch below to better testing,
[test_rocksdb_open_with_ttl.patch.zip](https://github.com/xyb/rocksdb3/files/7969314/test_rocksdb_open_with_ttl.patch.zip)


Note: when I run `rustfmt`, it changes the code quite much so I have skipped that part. 